### PR TITLE
Python 3 port with keeping Python 2 compliance

### DIFF
--- a/experimental/bluepy/commBLE.py
+++ b/experimental/bluepy/commBLE.py
@@ -57,7 +57,7 @@ class BLEDongle(Dongle):
 
 	def exchange(self, apdu, timeout=20000):
 		if self.debug:
-			print "=> %s" % hexlify(apdu)
+			print("=> %s" % hexlify(apdu))
 		apdu = wrapCommandAPDU(0, apdu, DEFAULT_BLE_CHUNK, True)		
 		offset = 0
 		while(offset < len(apdu)):			
@@ -78,7 +78,7 @@ class BLEDongle(Dongle):
 		sw = (result[swOffset] << 8) + result[swOffset + 1]
 		response = result[dataStart : dataLength + dataStart]
 		if self.debug:
-			print "<= %s%.2x" % (hexlify(response), sw)
+			print("<= %s%.2x" % (hexlify(response), sw))
 		if sw <> 0x9000:
 			raise CommException("Invalid status %04x" % sw, sw)
 		return response

--- a/ledgerblue/comm.py
+++ b/ledgerblue/comm.py
@@ -23,6 +23,7 @@ from .ledgerWrapper import wrapCommandAPDU, unwrapResponseAPDU
 from binascii import hexlify
 import hid
 import time
+import sys
 
 try:
 	from smartcard.Exceptions import NoCardException
@@ -31,6 +32,14 @@ try:
 	SCARD = True
 except ImportError:
 	SCARD = False
+
+	
+def hexstr(bstr):
+	if (sys.version_info.major == 3):
+		return hexlify(bstr).decode()
+	if (sys.version_info.major == 2):
+		return hexlify(bstr)
+	return "<undecoded APDU<"
 
 class DongleWait(object):
 	__metaclass__ = ABCMeta
@@ -64,15 +73,15 @@ class HIDDongleHIDAPI(Dongle, DongleWait):
 
 	def exchange(self, apdu, timeout=20):
 		if self.debug:
-			print "=> %s" % hexlify(apdu)
+			print("=> %s" % hexstr(apdu))
 		if self.ledger:
 			apdu = wrapCommandAPDU(0x0101, apdu, 64)		
 		padSize = len(apdu) % 64
 		tmp = apdu
-		if padSize <> 0:
+		if padSize != 0:
 			tmp.extend([0] * (64 - padSize))
 		offset = 0
-		while(offset <> len(tmp)):
+		while(offset != len(tmp)):
 			data = tmp[offset:offset + 64]
 			data = bytearray([0]) + data
 			self.device.write(data)
@@ -114,8 +123,8 @@ class HIDDongleHIDAPI(Dongle, DongleWait):
 		sw = (result[swOffset] << 8) + result[swOffset + 1]
 		response = result[dataStart : dataLength + dataStart]
 		if self.debug:
-			print "<= %s%.2x" % (hexlify(response), sw)
-		if sw <> 0x9000:
+			print("<= %s%.2x" % (hexstr(response), sw))
+		if sw != 0x9000:
 			raise CommException("Invalid status %04x" % sw, sw)
 		return response
 
@@ -148,12 +157,12 @@ class DongleSmartcard(Dongle):
 
 	def exchange(self, apdu, timeout=20):
 		if self.debug:
-			print "=> %s" % hexlify(apdu)
+			print("=> %s" % hexstr(apdu))
 		response, sw1, sw2 = self.device.transmit(toBytes(hexlify(apdu)))
 		sw = (sw1 << 8) | sw2
 		if self.debug:
-			print "<= %s%.2x" % (toHexString(response).replace(" ", ""), sw)
-		if sw <> 0x9000:
+			print("<= %s%.2x" % (hexstr(response).replace(" ", ""), sw))
+		if sw != 0x9000:
 			raise CommException("Invalid status %04x" % sw, sw)
 		return bytearray(response)
 
@@ -183,7 +192,7 @@ def getDongle(debug=False, selectCommand=None):
 			try:
 				connection = reader.createConnection()
 				connection.connect()				
-				if selectCommand <> None:
+				if selectCommand != None:
 					response, sw1, sw2 = connection.transmit(toBytes("00A4040010FF4C4547522E57414C5430312E493031"))																  
 					sw = (sw1 << 8) | sw2
 					if sw == 0x9000:

--- a/ledgerblue/deleteApp.py
+++ b/ledgerblue/deleteApp.py
@@ -22,6 +22,8 @@ from .comm import getDongle
 from .deployed import getDeployedSecretV1, getDeployedSecretV2
 from .hexLoader import HexLoader
 import argparse
+import binascii
+import sys
 
 def auto_int(x):
     return int(x, 0)
@@ -37,13 +39,19 @@ args = parser.parse_args()
 
 if args.appName == None:
 	raise Exception("Missing appName")
+    
+if (sys.version_info.major == 3):
+	args.appName = bytes(args.appName,'ascii')
+if (sys.version_info.major == 2):
+	args.appName = bytes(args.appName)
+
 if args.targetId == None:
 	args.targetId = 0x31000002
 if args.rootPrivateKey == None:
 	privateKey = PrivateKey()
-	publicKey = str(privateKey.pubkey.serialize(compressed=False)).encode('hex')
-	print "Generated random root public key : " + publicKey
-	args.rootPrivateKey = privateKey.serialize().encode('ascii')
+	publicKey = binascii.hexlify(privateKey.pubkey.serialize(compressed=False))
+	print("Generated random root public key : %s" % publicKey)
+	args.rootPrivateKey = privateKey.serialize()
 
 dongle = getDongle(args.apdu)
 

--- a/ledgerblue/ecWrapper.py
+++ b/ledgerblue/ecWrapper.py
@@ -58,23 +58,23 @@ class PublicKey(object):
 			return self.obj.serialize(compressed)
 		else:
 			if not compressed:
-				out = "\x04"
-				out += str(bytearray(self.obj.W.x.to_bytes(32, 'big')))
-				out += str(bytearray(self.obj.W.y.to_bytes(32, 'big')))
+				out = b"\x04"
+				out += self.obj.W.x.to_bytes(32, 'big')
+				out += self.obj.W.y.to_bytes(32, 'big')
 			else:
-				out = "\x03" if ((self.obj.W.y & 1) <> 0) else "\x02"
-				out += str(bytearray(self.obj.W.x.to_bytes(32, 'big')))
+				out = b"\x03" if ((self.obj.W.y & 1) != 0) else "\x02"
+				out += self.obj.W.x.to_bytes(32, 'big')
 			return out
 
 	def ecdh(self, scalar):
 		if USE_SECP:
 			return self.obj.ecdh(scalar)
 		else:
-			scalar = int.from_bytes(scalar)
+			scalar = int.from_bytes(scalar, 'big')
 			point = self.obj.W * scalar
 			# libsecp256k1 style secret
-			out = "\x03" if ((point.y & 1) <> 0) else "\x02"
-			out += str(bytearray(point.x.to_bytes(32, 'big')))
+			out = b"\x03" if ((point.y & 1) != 0) else b"\x02"
+			out += point.x.to_bytes(32, 'big')
 			hash = hashlib.sha256()
 			hash.update(out)
 			return hash.digest()
@@ -104,19 +104,19 @@ class PrivateKey(object):
 			if privkey == None:
 				privkey = ecpy.ecrand.rnd(CURVE_SECP256K1.order)
 			else:
-				privkey = int.from_bytes(privkey)
+				privkey = int.from_bytes(privkey,'big')
 			self.obj = ECPrivateKey(privkey, CURVE_SECP256K1)
 			pubkey = self.obj.get_public_key().W
-			out = "\x04"
-			out += str(bytearray(pubkey.x.to_bytes(32, 'big')))
-			out += str(bytearray(pubkey.y.to_bytes(32, 'big')))
+			out = b"\x04"
+			out += pubkey.x.to_bytes(32, 'big')
+			out += pubkey.y.to_bytes(32, 'big')
 			self.pubkey = PublicKey(out, raw=True)
 
 	def serialize(self):
 		if USE_SECP:
 			return self.obj.serialize()
 		else:
-			return str(bytearray(self.obj.d.to_bytes(32, 'big'))).encode('hex')
+			return "%.64x"%self.obj.d
 
 	def ecdsa_serialize(self, raw_sig):
 		if USE_SECP:

--- a/ledgerblue/hexParser.py
+++ b/ledgerblue/hexParser.py
@@ -36,16 +36,16 @@ class IntelHexParser:
 		startZone = None
 		startFirst = None
 		current = None
-		zoneData = ""
+		zoneData = b''
 		file = open(fileName, "r")
 		for data in file:
 			lineNumber += 1
 			data = data.rstrip('\r\n')
 			if len(data) == 0:
 				continue
-			if data[0] <> ':':
-				raise Exception("Invalid data at line " + str(lineNumber))
-			data = bytearray(data[1:].decode('hex'))		
+			if data[0] != ':':
+				raise Exception("Invalid data at line %d" % lineNumber)
+			data = bytearray.fromhex(data[1:]) #binascii.unhexlify(data[1:])		 
 			count = data[0]
 			address = (data[1] << 8) + data[2]
 			recordType = data[3]
@@ -55,7 +55,7 @@ class IntelHexParser:
 				if startFirst == None:
 					startFirst = address
 					current = startFirst
-				if address <> current:
+				if address != current:
 					self.areas.append(IntelHexArea((startZone << 16) + startFirst, zoneData))
 					zoneData = ""
 					startFirst = address
@@ -63,7 +63,7 @@ class IntelHexParser:
 				zoneData += data[4:4 + count]
 				current += count
 			if recordType == 0x01:
-				if len(zoneData) <> 0:
+				if len(zoneData) != 0:
 					self.areas.append(IntelHexArea((startZone << 16) + startFirst, zoneData))
 					zoneData = ""
 					startZone = None
@@ -74,7 +74,7 @@ class IntelHexParser:
 			if recordType == 0x03:
 					raise Exception("Unsupported record 03")
 			if recordType == 0x04:
-					if len(zoneData) <> 0:
+					if len(zoneData) != 0:
 						self.areas.append(IntelHexArea((startZone << 16) + startFirst, zoneData))
 						zoneData = ""
 						startZone = None

--- a/ledgerblue/ledgerWrapper.py
+++ b/ledgerblue/ledgerWrapper.py
@@ -39,7 +39,7 @@ def wrapCommandAPDU(channel, command, packetSize, ble=False):
 		blockSize = len(command)
 	result += command[offset : offset + blockSize]
 	offset = offset + blockSize
-	while offset <> len(command):
+	while offset != len(command):
 		if not ble:
 			result += struct.pack(">H", channel) 		
 		result += struct.pack(">BH", 0x05, sequenceIdx)
@@ -51,8 +51,8 @@ def wrapCommandAPDU(channel, command, packetSize, ble=False):
 		result += command[offset : offset + blockSize]
 		offset = offset + blockSize
 	if not ble:		
-		while (len(result) % packetSize) <> 0:
-			result += "\x00"
+		while (len(result) % packetSize) != 0:
+			result += b"\x00"
 	return bytearray(result)
 
 def unwrapResponseAPDU(channel, data, packetSize, ble=False):
@@ -65,16 +65,16 @@ def unwrapResponseAPDU(channel, data, packetSize, ble=False):
 	if ((data is None) or (len(data) < 5 + extraHeaderSize + 5)):
 		return None
 	if not ble:
-		if struct.unpack(">H", str(data[offset : offset + 2]))[0] <> channel:
+		if struct.unpack(">H", data[offset : offset + 2])[0] != channel:
 			raise CommException("Invalid channel")
 		offset += 2
-	if data[offset] <> 0x05:
+	if data[offset] != 0x05:
 		raise CommException("Invalid tag")
 	offset += 1
-	if struct.unpack(">H", str(data[offset : offset + 2]))[0] <> sequenceIdx:
+	if struct.unpack(">H", data[offset : offset + 2])[0] != sequenceIdx:
 		raise CommException("Invalid sequence")
 	offset += 2
-	responseLength = struct.unpack(">H", str(data[offset : offset + 2]))[0]
+	responseLength = struct.unpack(">H", data[offset : offset + 2])[0]
 	offset += 2
 	if len(data) < 5 + extraHeaderSize + responseLength:
 		return None
@@ -84,18 +84,18 @@ def unwrapResponseAPDU(channel, data, packetSize, ble=False):
 		blockSize = responseLength
 	result = data[offset : offset + blockSize]
 	offset += blockSize
-	while (len(result) <> responseLength):
+	while (len(result) != responseLength):
 		sequenceIdx = sequenceIdx + 1
 		if (offset == len(data)):
 			return None
 		if not ble:
-			if struct.unpack(">H", str(data[offset : offset + 2]))[0] <> channel:
+			if struct.unpack(">H", data[offset : offset + 2])[0] != channel:
 				raise CommException("Invalid channel")
 			offset += 2
-		if data[offset] <> 0x05:
+		if data[offset] != 0x05:
 			raise CommException("Invalid tag")
 		offset += 1
-		if struct.unpack(">H", str(data[offset : offset + 2]))[0] <> sequenceIdx:
+		if struct.unpack(">H", data[offset : offset + 2])[0] != sequenceIdx:
 			raise CommException("Invalid sequence")
 		offset += 2
 		if (responseLength - len(result)) > packetSize - 3 - extraHeaderSize:

--- a/ledgerblue/runScript.py
+++ b/ledgerblue/runScript.py
@@ -48,14 +48,14 @@ else:
 class SCP:
 	def __init__(self, dongle, targetId, rootPrivateKey):
 		self.key = getDeployedSecretV2(dongle, rootPrivateKey, targetId)
-		self.iv = "\x00" * 16;
+		self.iv = b'\x00' * 16;
 		
 	def encryptAES(self, data):
-		paddedData = data + '\x80'
-		while (len(paddedData) % 16) <> 0:
-			paddedData += '\x00'
+		paddedData = data + b'\x80'
+		while (len(paddedData) % 16) != 0:
+			paddedData += b'\x00'
 		cipher = AES.new(self.key, AES.MODE_CBC, self.iv)
-		encryptedData = cipher.encrypt(str(paddedData))
+		encryptedData = cipher.encrypt(paddedData)
 		self.iv = encryptedData[len(encryptedData) - 16:]
 		return encryptedData
 
@@ -64,9 +64,9 @@ dongle = getDongle(args.apdu)
 if args.scp:
 	if args.rootPrivateKey == None:
 		privateKey = PrivateKey()
-		publicKey = str(privateKey.pubkey.serialize(compressed=False)).encode('hex')
-		print "Generated random root public key : " + publicKey
-		args.rootPrivateKey = privateKey.serialize().encode('ascii')
+		publicKey = binascii.hexlify(privateKey.pubkey.serialize(compressed=False))
+		print("Generated random root public key : %s" % publicKey)
+		args.rootPrivateKey = privateKey.serialize()
 		scp = SCP(dongle, args.targetId, bytearray.fromhex(args.rootPrivateKey))
 
 for data in file:

--- a/ledgerblue/signApp.py
+++ b/ledgerblue/signApp.py
@@ -50,11 +50,11 @@ dataToSign = m.digest()
 
 MASTER_PRIVATE = bytearray.fromhex(args.key)
 testMaster = PrivateKey(bytes(MASTER_PRIVATE))
-testMasterPublic = bytearray(testMaster.pubkey.serialize(compressed=False))
+#testMasterPublic = bytearray(testMaster.pubkey.serialize(compressed=False))
 
 signature = testMaster.ecdsa_sign(bytes(dataToSign), raw=True)
 
 # test signature before printing it
 if testMaster.pubkey.ecdsa_verify(dataToSign, signature, raw=True):
-	#print "Signer's public: " + binascii.hexlify(testMasterPublic)
-	print testMaster.ecdsa_serialize(signature).encode('hex')
+	#print("Signer's public: " + binascii.hexlify(testMasterPublic))
+	print(testMaster.ecdsa_serialize(signature).encode('hex'))

--- a/ledgerblue/verifyApp.py
+++ b/ledgerblue/verifyApp.py
@@ -56,4 +56,4 @@ signature = publicKey.ecdsa_deserialize(bytes(bytearray.fromhex(args.signature))
 if not publicKey.ecdsa_verify(bytes(dataToSign), signature, raw=True):
 	raise Exception("Signature not verified")
 
-print "Signature verified"
+print("Signature verified")


### PR DESCRIPTION
  Add missing () around print arguments
  Replace <> with !=
  Fix bytes/str compliance

Status
  loadApp.py and deleteApp.py works with both python 2.7.12 and 3.5.2 on BlueLedger 1.2
  sign.py is untested because it requires en hsm access