### PR TITLE
add received data in CommException object

### DIFF
--- a/ledgerblue/comm.py
+++ b/ledgerblue/comm.py
@@ -125,7 +125,7 @@ class HIDDongleHIDAPI(Dongle, DongleWait):
 		if self.debug:
 			print("<= %s%.2x" % (hexstr(response), sw))
 		if sw != 0x9000:
-			raise CommException("Invalid status %04x" % sw, sw)
+			raise CommException("Invalid status %04x" % sw, sw, response)
 		return response
 
 	def waitFirstResponse(self, timeout):
@@ -163,7 +163,7 @@ class DongleSmartcard(Dongle):
 		if self.debug:
 			print("<= %s%.2x" % (hexstr(response).replace(" ", ""), sw))
 		if sw != 0x9000:
-			raise CommException("Invalid status %04x" % sw, sw)
+			raise CommException("Invalid status %04x" % sw, sw, bytearray(response))
 		return bytearray(response)
 
 	def close(self):

--- a/ledgerblue/commException.py
+++ b/ledgerblue/commException.py
@@ -19,9 +19,10 @@
 
 class CommException(Exception):
 
-	def __init__(self, message, sw=0x6f00):
+	def __init__(self, message, sw=0x6f00, data=None):
 		self.message = message
 		self.sw = sw
+		self.data = data
 
 	def __str__(self):
 		buf = "Exception : " + self.message


### PR DESCRIPTION
Dongle IO protocol expects all status word to be 9000 and throw exception if not.
The thrown exception contains only the sw!=9000.
This request also  add the received data in the CommException object