### PR TITLE
Fix of TypeError

### DIFF
--- a/ledgerblue/hexLoader.py
+++ b/ledgerblue/hexLoader.py
@@ -92,7 +92,7 @@ class HexLoader:
 		while (len(paddedData) % 16) != 0:
 			paddedData += b'\x00'
 		cipher = AES.new(self.key, AES.MODE_CBC, self.iv)
-		encryptedData = cipher.encrypt(paddedData)
+		encryptedData = cipher.encrypt(buffer(paddedData))
 		self.iv = encryptedData[len(encryptedData) - 16:]
 		return encryptedData
 


### PR DESCRIPTION
TypeError: argument must be string or read-only buffer, not bytearray

Closes LedgerHQ/blue-app-btc#16