### PR TITLE
Print public key in checkGenuine.py

### DIFF
--- a/ledgerblue/checkGenuine.py
+++ b/ledgerblue/checkGenuine.py
@@ -119,8 +119,11 @@ if __name__ == '__main__':
 			args.issuerKey = "0490f5c9d15a0134bb019d2afd0bf297149738459706e7ac5be4abc350a1f818057224fce12ec9a65de18ec34d6e8c24db927835ea1692b14c32e9836a75dad609"
 
 	privateKey = PrivateKey()
-	publicKey = str(privateKey.pubkey.serialize(compressed=False))
 	args.rootPrivateKey = privateKey.serialize()
+
+	publicKey = binascii.hexlify(privateKey.pubkey.serialize(compressed=False))
+	print ("Public Key")
+	print (publicKey.decode().upper())
 
 	genuine = False
 


### PR DESCRIPTION
Running the `checkGenuine.py` script from the cli prompts the Ledger Nano S device to display the message: `Allow unknown device?` along with a public key which is randomly generated each run.

This is confusing for end-users as they have no way of verifying this randomly generated public key.

This PR updates `checkGenuine.py` to print out the public key during each run.