### PR TITLE
Fix space before semicolon in genCAPair output

### DIFF
--- a/ledgerblue/genCAPair.py
+++ b/ledgerblue/genCAPair.py
@@ -43,5 +43,5 @@ if __name__ == '__main__':
 	get_argparser().parse_args()
 	privateKey = PrivateKey()
 	publicKey = hexstr(privateKey.pubkey.serialize(compressed=False))
-	print("Public key : %s" % publicKey)
+	print("Public key: %s" % publicKey)
 	print("Private key: %s" % privateKey.serialize())


### PR DESCRIPTION
## Description

_This couldn't be more trivial_... **but**, this is for ease of parsing when making use of this programatically. This will make using tools such as `awk` or `sed` to parse the output of this more easily.

## Changes

* Removed superfluous space between colon and text of `Private key`