### PR TITLE
Bugfix for Python 3 in Intel Hex Parser

### DIFF
--- a/ledgerblue/deployed.py
+++ b/ledgerblue/deployed.py
@@ -17,160 +17,160 @@
 ********************************************************************************
 """
 
-from .ecWrapper import PrivateKey, PublicKey
-import os
-import sys
-import struct
-from .hexParser import IntelHexParser
-from .hexLoader import HexLoader
 import binascii
+import os
+import struct
+
+from .ecWrapper import PrivateKey, PublicKey
+
 
 def getDeployedSecretV1(dongle, masterPrivate, targetId):
-	testMaster = PrivateKey(bytes(masterPrivate))
-	testMasterPublic = bytearray(testMaster.pubkey.serialize(compressed=False))
-	targetid = bytearray(struct.pack('>I', targetId))
+    testMaster = PrivateKey(bytes(masterPrivate))
+    testMasterPublic = bytearray(testMaster.pubkey.serialize(compressed=False))
+    targetid = bytearray(struct.pack('>I', targetId))
 
-	if targetId&0xF != 0x1:
-		raise BaseException("Target ID does not support SCP V1")
+    if targetId & 0xF != 0x1:
+        raise BaseException("Target ID does not support SCP V1")
 
-	# identify
-	apdu = bytearray([0xe0, 0x04, 0x00, 0x00]) + bytearray([len(targetid)]) + targetid
-	dongle.exchange(apdu)
+    # identify
+    apdu = bytearray([0xe0, 0x04, 0x00, 0x00]) + bytearray([len(targetid)]) + targetid
+    dongle.exchange(apdu)
 
-	# walk the chain 
-	batch_info = bytearray(dongle.exchange(bytearray.fromhex('E050000000')))
-	cardKey = batch_info[5:5 + batch_info[4]]
+    # walk the chain
+    batch_info = bytearray(dongle.exchange(bytearray.fromhex('E050000000')))
+    cardKey = batch_info[5:5 + batch_info[4]]
 
-	# if not found, get another pair
-	#if cardKey != testMasterPublic:
-	#	raise Exception("Invalid batch public key")
+    # if not found, get another pair
+    # if cardKey != testMasterPublic:
+    #	raise Exception("Invalid batch public key")
 
-	# provide the ephemeral certificate
-	ephemeralPrivate = PrivateKey()
-	ephemeralPublic = bytearray(ephemeralPrivate.pubkey.serialize(compressed=False))
-	print("Using ephemeral key %s" %binascii.hexlify(ephemeralPublic))
-	signature = testMaster.ecdsa_sign(bytes(ephemeralPublic))
-	signature = testMaster.ecdsa_serialize(signature)
-	certificate = bytearray([len(ephemeralPublic)]) + ephemeralPublic + bytearray([len(signature)]) + signature
-	apdu = bytearray([0xE0, 0x51, 0x00, 0x00]) + bytearray([len(certificate)]) + certificate
-	dongle.exchange(apdu)
+    # provide the ephemeral certificate
+    ephemeralPrivate = PrivateKey()
+    ephemeralPublic = bytearray(ephemeralPrivate.pubkey.serialize(compressed=False))
+    print("Using ephemeral key %s" % binascii.hexlify(ephemeralPublic))
+    signature = testMaster.ecdsa_sign(bytes(ephemeralPublic))
+    signature = testMaster.ecdsa_serialize(signature)
+    certificate = bytearray([len(ephemeralPublic)]) + ephemeralPublic + bytearray([len(signature)]) + signature
+    apdu = bytearray([0xE0, 0x51, 0x00, 0x00]) + bytearray([len(certificate)]) + certificate
+    dongle.exchange(apdu)
 
-	# walk the device certificates to retrieve the public key to use for authentication
-	index = 0
-	last_pub_key = PublicKey(bytes(testMasterPublic), raw=True)
-	while True:
-		certificate = bytearray(dongle.exchange(bytearray.fromhex('E052000000')))
-		if len(certificate) == 0:
-			break
-		certificatePublic = certificate[1 : 1 + certificate[0]]
-		certificateSignature = last_pub_key.ecdsa_deserialize(bytes(certificate[2 + certificate[0] :]))		
-		if not last_pub_key.ecdsa_verify(bytes(certificatePublic), certificateSignature):
-			if index == 0:
-				# Not an error if loading from user key
-				print("Broken certificate chain - loading from user key")
-			else:
-				raise Exception("Broken certificate chain")
-		last_pub_key = PublicKey(bytes(certificatePublic), raw=True)
-		index = index + 1
+    # walk the device certificates to retrieve the public key to use for authentication
+    index = 0
+    last_pub_key = PublicKey(bytes(testMasterPublic), raw=True)
+    while True:
+        certificate = bytearray(dongle.exchange(bytearray.fromhex('E052000000')))
+        if len(certificate) == 0:
+            break
+        certificatePublic = certificate[1: 1 + certificate[0]]
+        certificateSignature = last_pub_key.ecdsa_deserialize(bytes(certificate[2 + certificate[0]:]))
+        if not last_pub_key.ecdsa_verify(bytes(certificatePublic), certificateSignature):
+            if index == 0:
+                # Not an error if loading from user key
+                print("Broken certificate chain - loading from user key")
+            else:
+                raise Exception("Broken certificate chain")
+        last_pub_key = PublicKey(bytes(certificatePublic), raw=True)
+        index = index + 1
 
-	# Commit device ECDH channel
-	dongle.exchange(bytearray.fromhex('E053000000'))
-	secret = last_pub_key.ecdh(bytes(ephemeralPrivate.serialize().decode('hex')))
-	return secret[0:16]
+    # Commit device ECDH channel
+    dongle.exchange(bytearray.fromhex('E053000000'))
+    secret = last_pub_key.ecdh(bytes(ephemeralPrivate.serialize().decode('hex')))
+    return secret[0:16]
+
 
 def getDeployedSecretV2(dongle, masterPrivate, targetId, signerCertChain=None, ecdh_secret_format=None):
-	testMaster = PrivateKey(bytes(masterPrivate))
-	testMasterPublic = bytearray(testMaster.pubkey.serialize(compressed=False))
-	targetid = bytearray(struct.pack('>I', targetId))
+    testMaster = PrivateKey(bytes(masterPrivate))
+    testMasterPublic = bytearray(testMaster.pubkey.serialize(compressed=False))
+    targetid = bytearray(struct.pack('>I', targetId))
 
-	if targetId&0xF < 3:
-		raise BaseException("Target ID does not support SCP V2")
+    if targetId & 0xF < 3:
+        raise BaseException("Target ID does not support SCP V2")
 
-	# identify
-	apdu = bytearray([0xe0, 0x04, 0x00, 0x00]) + bytearray([len(targetid)]) + targetid
-	dongle.exchange(apdu)
+    # identify
+    apdu = bytearray([0xe0, 0x04, 0x00, 0x00]) + bytearray([len(targetid)]) + targetid
+    dongle.exchange(apdu)
 
-	# walk the chain 
-	nonce = os.urandom(8)
-	apdu = bytearray([0xe0, 0x50, 0x00, 0x00]) + bytearray([len(nonce)]) + nonce
-	auth_info = dongle.exchange(apdu)
-	batch_signer_serial = auth_info[0:4]
-	deviceNonce = auth_info[4:12]
+    # walk the chain
+    nonce = os.urandom(8)
+    apdu = bytearray([0xe0, 0x50, 0x00, 0x00]) + bytearray([len(nonce)]) + nonce
+    auth_info = dongle.exchange(apdu)
+    batch_signer_serial = auth_info[0:4]
+    deviceNonce = auth_info[4:12]
 
-	# if not found, get another pair
-	#if cardKey != testMasterPublic:
-	#	raise Exception("Invalid batch public key")
+    # if not found, get another pair
+    # if cardKey != testMasterPublic:
+    #	raise Exception("Invalid batch public key")
 
-	if (signerCertChain):
-		for cert in signerCertChain:
-			apdu = bytearray([0xE0, 0x51, 0x00, 0x00]) + bytearray([len(cert)]) + cert
-			dongle.exchange(apdu)
-	else:
-		print("Using test master key %s " % binascii.hexlify(testMasterPublic))
-		dataToSign = bytes(bytearray([0x01]) + testMasterPublic)
-		signature = testMaster.ecdsa_sign(bytes(dataToSign))
-		signature = testMaster.ecdsa_serialize(signature)
-		certificate = bytearray([len(testMasterPublic)]) + testMasterPublic + bytearray([len(signature)]) + signature
-		apdu = bytearray([0xE0, 0x51, 0x00, 0x00]) + bytearray([len(certificate)]) + certificate
-		dongle.exchange(apdu)
-	
-	# provide the ephemeral certificate
-	ephemeralPrivate = PrivateKey()
-	ephemeralPublic = bytearray(ephemeralPrivate.pubkey.serialize(compressed=False))
-	print("Using ephemeral key %s" %binascii.hexlify(ephemeralPublic))
-	dataToSign = bytes(bytearray([0x11]) + nonce + deviceNonce + ephemeralPublic)
-	signature = testMaster.ecdsa_sign(bytes(dataToSign))
-	signature = testMaster.ecdsa_serialize(signature)
-	certificate = bytearray([len(ephemeralPublic)]) + ephemeralPublic + bytearray([len(signature)]) + signature
-	apdu = bytearray([0xE0, 0x51, 0x80, 0x00]) + bytearray([len(certificate)]) + certificate
-	dongle.exchange(apdu)
+    if (signerCertChain):
+        for cert in signerCertChain:
+            apdu = bytearray([0xE0, 0x51, 0x00, 0x00]) + bytearray([len(cert)]) + cert
+            dongle.exchange(apdu)
+    else:
+        print("Using test master key %s " % binascii.hexlify(testMasterPublic))
+        dataToSign = bytes(bytearray([0x01]) + testMasterPublic)
+        signature = testMaster.ecdsa_sign(bytes(dataToSign))
+        signature = testMaster.ecdsa_serialize(signature)
+        certificate = bytearray([len(testMasterPublic)]) + testMasterPublic + bytearray([len(signature)]) + signature
+        apdu = bytearray([0xE0, 0x51, 0x00, 0x00]) + bytearray([len(certificate)]) + certificate
+        dongle.exchange(apdu)
 
-	# walk the device certificates to retrieve the public key to use for authentication
-	index = 0
-	last_dev_pub_key = PublicKey(bytes(testMasterPublic), raw=True)
-	devicePublicKey = None
-	while True:
-		if index == 0:			
-			certificate = bytearray(dongle.exchange(bytearray.fromhex('E052000000')))
-		elif index == 1:
-			certificate = bytearray(dongle.exchange(bytearray.fromhex('E052800000')))
-		else:
-			break
-		if len(certificate) == 0:
-			break
-		offset = 1
-		certificateHeader = certificate[offset : offset + certificate[offset-1]]
-		offset += certificate[offset-1] + 1
-		certificatePublicKey = certificate[offset : offset + certificate[offset-1]]
-		offset += certificate[offset-1] + 1
-		certificateSignatureArray = certificate[offset : offset + certificate[offset-1]]
-		certificateSignature = last_dev_pub_key.ecdsa_deserialize(bytes(certificateSignatureArray))
-		# first cert contains a header field which holds the certificate's public key role
-		if index == 0:
-			devicePublicKey = certificatePublicKey
-			certificateSignedData = bytearray([0x02]) + certificateHeader + certificatePublicKey
-			# Could check if the device certificate is signed by the issuer public key
-		# ephemeral key certificate
-		else:
-			certificateSignedData = bytearray([0x12]) + deviceNonce + nonce + certificatePublicKey		
-		if not last_dev_pub_key.ecdsa_verify(bytes(certificateSignedData), certificateSignature):
-			if index == 0:
-				# Not an error if loading from user key
-				print("Broken certificate chain - loading from user key")
-			else:
-				raise Exception("Broken certificate chain")
-		last_dev_pub_key = PublicKey(bytes(certificatePublicKey), raw=True)
-		index = index + 1
+    # provide the ephemeral certificate
+    ephemeralPrivate = PrivateKey()
+    ephemeralPublic = bytearray(ephemeralPrivate.pubkey.serialize(compressed=False))
+    print("Using ephemeral key %s" % binascii.hexlify(ephemeralPublic))
+    dataToSign = bytes(bytearray([0x11]) + nonce + deviceNonce + ephemeralPublic)
+    signature = testMaster.ecdsa_sign(bytes(dataToSign))
+    signature = testMaster.ecdsa_serialize(signature)
+    certificate = bytearray([len(ephemeralPublic)]) + ephemeralPublic + bytearray([len(signature)]) + signature
+    apdu = bytearray([0xE0, 0x51, 0x80, 0x00]) + bytearray([len(certificate)]) + certificate
+    dongle.exchange(apdu)
 
-	# Commit device ECDH channel
-	dongle.exchange(bytearray.fromhex('E053000000'))
-	secret = last_dev_pub_key.ecdh(binascii.unhexlify(ephemeralPrivate.serialize()))
+    # walk the device certificates to retrieve the public key to use for authentication
+    index = 0
+    last_dev_pub_key = PublicKey(bytes(testMasterPublic), raw=True)
+    devicePublicKey = None
+    while True:
+        if index == 0:
+            certificate = bytearray(dongle.exchange(bytearray.fromhex('E052000000')))
+        elif index == 1:
+            certificate = bytearray(dongle.exchange(bytearray.fromhex('E052800000')))
+        else:
+            break
+        if len(certificate) == 0:
+            break
+        offset = 1
+        certificateHeader = certificate[offset: offset + certificate[offset - 1]]
+        offset += certificate[offset - 1] + 1
+        certificatePublicKey = certificate[offset: offset + certificate[offset - 1]]
+        offset += certificate[offset - 1] + 1
+        certificateSignatureArray = certificate[offset: offset + certificate[offset - 1]]
+        certificateSignature = last_dev_pub_key.ecdsa_deserialize(bytes(certificateSignatureArray))
+        # first cert contains a header field which holds the certificate's public key role
+        if index == 0:
+            devicePublicKey = certificatePublicKey
+            certificateSignedData = bytearray([0x02]) + certificateHeader + certificatePublicKey
+        # Could check if the device certificate is signed by the issuer public key
+        # ephemeral key certificate
+        else:
+            certificateSignedData = bytearray([0x12]) + deviceNonce + nonce + certificatePublicKey
+        if not last_dev_pub_key.ecdsa_verify(bytes(certificateSignedData), certificateSignature):
+            if index == 0:
+                # Not an error if loading from user key
+                print("Broken certificate chain - loading from user key")
+            else:
+                raise Exception("Broken certificate chain")
+        last_dev_pub_key = PublicKey(bytes(certificatePublicKey), raw=True)
+        index = index + 1
 
-	#forced to specific version
-	if ecdh_secret_format==1 or targetId&0xF == 0x2:
-		return secret[0:16]
-	elif targetId&0xF >= 0x3:
-		ret = {}
-		ret['ecdh_secret'] = secret
-		ret['devicePublicKey'] = devicePublicKey
-		return ret
+    # Commit device ECDH channel
+    dongle.exchange(bytearray.fromhex('E053000000'))
+    secret = last_dev_pub_key.ecdh(binascii.unhexlify(ephemeralPrivate.serialize()))
+
+    # forced to specific version
+    if ecdh_secret_format == 1 or targetId & 0xF == 0x2:
+        return secret[0:16]
+    elif targetId & 0xF >= 0x3:
+        ret = {}
+        ret['ecdh_secret'] = secret
+        ret['devicePublicKey'] = devicePublicKey
+        return ret

--- a/ledgerblue/hashApp.py
+++ b/ledgerblue/hashApp.py
@@ -19,41 +19,45 @@
 
 import argparse
 
+
 def get_argparser():
-	parser = argparse.ArgumentParser(description="Calculate an application hash from the application's hex file.")
-	parser.add_argument("--hex", help="The application hex file to be hashed")
-	return parser
+    parser = argparse.ArgumentParser(description="Calculate an application hash from the application's hex file.")
+    parser.add_argument("--hex", help="The application hex file to be hashed")
+    return parser
+
 
 def auto_int(x):
-	return int(x, 0)
+    return int(x, 0)
+
 
 def hexstr(bstr):
-	if (sys.version_info.major == 3):
-		return binascii.hexlify(bstr).decode()
-	if (sys.version_info.major == 2):
-		return binascii.hexlify(bstr)
-	return ""
+    if (sys.version_info.major == 3):
+        return binascii.hexlify(bstr).decode()
+    if (sys.version_info.major == 2):
+        return binascii.hexlify(bstr)
+    return ""
+
 
 if __name__ == '__main__':
-	from .hexParser import IntelHexParser
-	from .hexParser import IntelHexPrinter
-	import sys
-	import hashlib
-	import binascii
+    from .hexParser import IntelHexParser
+    from .hexParser import IntelHexPrinter
+    import sys
+    import hashlib
+    import binascii
 
-	args = get_argparser().parse_args()
+    args = get_argparser().parse_args()
 
-	if args.hex == None:
-		raise Exception("Missing hex filename to hash")
+    if args.hex == None:
+        raise Exception("Missing hex filename to hash")
 
-	# parse
-	parser = IntelHexParser(args.hex)
+    # parse
+    parser = IntelHexParser(args.hex)
 
-	# prepare data
-	m = hashlib.sha256()
-	# consider areas are ordered by ascending address and non-overlaped
-	for a in parser.getAreas():
-		m.update(a.data)
-	dataToSign = m.digest()
+    # prepare data
+    m = hashlib.sha256()
+    # consider areas are ordered by ascending address and non-overlaped
+    for a in parser.getAreas():
+        m.update(a.data)
+    dataToSign = m.digest()
 
-	print(hexstr(dataToSign))
+    print(hexstr(dataToSign))

--- a/ledgerblue/hexParser.py
+++ b/ledgerblue/hexParser.py
@@ -72,7 +72,7 @@ class IntelHexParser:
                                         current = startFirst
                                 if address != current:
                                         self._addArea(IntelHexArea((startZone << 16) + startFirst, zoneData))
-                                        zoneData = ""
+                                        zoneData = b''
                                         startFirst = address
                                         current = address
                                 zoneData += data[4:4 + count]
@@ -80,7 +80,7 @@ class IntelHexParser:
                         if recordType == 0x01:
                                 if len(zoneData) != 0:
                                         self._addArea(IntelHexArea((startZone << 16) + startFirst, zoneData))
-                                        zoneData = ""
+                                        zoneData = b''
                                         startZone = None
                                         startFirst = None
                                         current = None                                        
@@ -91,7 +91,7 @@ class IntelHexParser:
                         if recordType == 0x04:
                                         if len(zoneData) != 0:
                                                 self._addArea(IntelHexArea((startZone << 16) + startFirst, zoneData))
-                                                zoneData = ""
+                                                zoneData = b''
                                                 startZone = None
                                                 startFirst = None
                                                 current = None                                                
@@ -198,7 +198,7 @@ class IntelHexPrinter:
                                 else:
                                         self._emit_binary(file, bytearray((hex(0x100+blocksize)[3:] + hex(0x10000+off+(area.start&0xFFFF))[3:] + "00").decode('hex')) + area.data[off:off+blocksize])
 
-                                oldoff = off;
+                                oldoff = off
                                 off += blocksize
                                 
                 bootAddrHex = hex(0x100000000+self.bootAddr)[3:]


### PR DESCRIPTION
In some conditions, the `zoneData` variable is initialized to str instead of bytes in the Intel Hex Parser, leading to an error in Python 3.