### PR TITLE
add TCP proxy support

### DIFF
--- a/ledgerblue/comm.py
+++ b/ledgerblue/comm.py
@@ -27,6 +27,7 @@ import os
 import sys
 from .commU2F import getDongle as getDongleU2F
 from .commHTTP import getDongle as getDongleHTTP
+from .commTCP import getDongle as getDongleTCP
 import hid
 
 APDUGEN=None
@@ -40,6 +41,11 @@ if "U2FKEY" in os.environ and len(os.environ["U2FKEY"]) != 0:
 MCUPROXY=None
 if "MCUPROXY" in os.environ and len(os.environ["MCUPROXY"]) != 0:
 	MCUPROXY=os.environ["MCUPROXY"]
+# Force use of TCP PROXY if required
+TCP_PROXY=None
+if "LEDGER_PROXY_ADDRESS" in os.environ and len(os.environ["LEDGER_PROXY_ADDRESS"]) != 0 and \
+   "LEDGER_PROXY_PORT" in os.environ and len(os.environ["LEDGER_PROXY_PORT"]) != 0:
+	TCP_PROXY=(os.environ["LEDGER_PROXY_ADDRESS"], int(os.environ["LEDGER_PROXY_PORT"]))
 	
 # Force use of MCUPROXY if required
 PCSC=None
@@ -190,8 +196,10 @@ def getDongle(debug=False, selectCommand=None):
 
 	if not U2FKEY is None:
 		return getDongleU2F(scrambleKey=U2FKEY, debug=debug)
-	if MCUPROXY is not None:
+	elif MCUPROXY is not None:
 		return getDongleHTTP(remote_host=MCUPROXY, debug=debug)
+	elif TCP_PROXY is not None:
+		return getDongleTCP(server=TCP_PROXY[0], port=TCP_PROXY[1], debug=debug)
 	dev = None
 	hidDevicePath = None
 	ledger = True

--- a/ledgerblue/commTCP.py
+++ b/ledgerblue/commTCP.py
@@ -1,0 +1,57 @@
+"""
+*******************************************************************************
+*   Ledger Blue
+*   (c) 2019 Ledger
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************
+"""
+
+from .commException import CommException
+from binascii import hexlify
+import socket
+import struct
+
+class DongleServer(object):
+	def __init__(self, server, port, debug=False):
+		self.server = server
+		self.port = port
+		self.debug = debug
+		self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		try:
+			self.socket.connect((self.server, self.port))
+		except:
+			raise CommException("Proxy connection failed")
+
+	def exchange(self, apdu, timeout=20000):
+		if self.debug:
+			print("=> %s" % hexlify(apdu))		
+		self.socket.send(struct.pack(">I", len(apdu)))
+		self.socket.send(apdu)
+		size = struct.unpack(">I", self.socket.recv(4))[0]
+		response = self.socket.recv(size)
+		sw = struct.unpack(">H", self.socket.recv(2))[0]
+		if self.debug:
+			print("<= %s%.2x" % (hexlify(response), sw))
+		if sw != 0x9000:
+			raise CommException("Invalid status %04x" % sw, sw)
+		return bytearray(response)
+
+	def close(self):
+		try:
+			self.socket.close()
+		except:
+			pass
+
+def getDongle(server="127.0.0.1", port=9999, debug=False):
+    return DongleServer(server, port, debug)


### PR DESCRIPTION
Copy/paste of btchip-python/btchip/btchipComm.py.

Usage:

    LEDGER_PROXY_ADDRESS=127.0.0.1 LEDGER_PROXY_PORT=9999 \
    python -m ledgerblue.listApps