### PR TITLE
Add a apduMaxDataSize method to the commTCP DongleServer class

### DIFF
--- a/ledgerblue/commTCP.py
+++ b/ledgerblue/commTCP.py
@@ -47,6 +47,9 @@ class DongleServer(object):
 			raise CommException("Invalid status %04x" % sw, sw)
 		return bytearray(response)
 
+	def apduMaxDataSize(self):
+		return 240
+
 	def close(self):
 		try:
 			self.socket.close()


### PR DESCRIPTION

That should fix the following error when using TCP:

```
echo 'e001000000' | LEDGER_PROXY_ADDRESS=127.0.0.1 LEDGER_PROXY_PORT=1237 python3 -m ledgerblue.runScript --apdu --scp --targetId 0x31100004
...
  File "/home/user/.local/lib/python3.6/site-packages/ledgerblue/runScript.py", line 82, in <module>
    scp = SCP(dongle, args.targetId, bytearray.fromhex(args.rootPrivateKey))
  File "/home/user/.local/lib/python3.6/site-packages/ledgerblue/runScript.py", line 67, in __init__
    self.loader = HexLoader(dongle, 0xe0, True, secret)
  File "/home/user/.local/lib/python3.6/site-packages/ledgerblue/hexLoader.py", line 122, in __init__
    self.max_mtu = min(self.max_mtu, self.card.apduMaxDataSize())
AttributeError: 'DongleServer' object has no attribute 'apduMaxDataSize'
```