### PR TITLE
Add support for more device statuses

### DIFF
--- a/ledgerblue/comm.py
+++ b/ledgerblue/comm.py
@@ -138,6 +138,10 @@ class HIDDongleHIDAPI(Dongle, DongleWait):
 				possibleCause = "Maybe this app requires a library to be installed first?"
 			if sw == 0x6484:
 				possibleCause = "Are you using the correct targetId?"
+			if sw == 0x6d00:
+				possibleCause = "Unexpected state of device: try closing the Bitcoin app?"
+			if sw == 0x6e00:
+				possibleCause = "Unexpected state of device: try opening U2F app?"
 			raise CommException("Invalid status %04x (%s)" % (sw, possibleCause), sw, response)
 		return response
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import os
 here = dirname(__file__)
 setup(
     name='ledgerblue',
-    version='0.1.28',
+    version='0.1.29',
     author='Ledger',
     author_email='hello@ledger.fr',
     description='Python library to communicate with Ledger Blue/Nano S',


### PR DESCRIPTION
Before this change, tools like `ledger-agent` [1] give cryptic errors
like the following if the device has the Bitcoin app or the dashboard
open:

```
ledgerblue.commException.CommException: Exception : Invalid status 6d00 (Unknown reason)
ledgerblue.commException.CommException: Exception : Invalid status 6e00 (Unknown reason)
```

After this change, we try to provide a hint that there's nothing wrong
with the user's device, but that it's in an unexpected state.

Fixes #26 #31.

[1] https://github.com/romanz/trezor-agent