### PR TITLE
[Hex over TCP] - Allows one to exchange data in hexadecimal format

### DIFF
--- a/ledgerblue/comm.py
+++ b/ledgerblue/comm.py
@@ -46,7 +46,11 @@ TCP_PROXY=None
 if "LEDGER_PROXY_ADDRESS" in os.environ and len(os.environ["LEDGER_PROXY_ADDRESS"]) != 0 and \
    "LEDGER_PROXY_PORT" in os.environ and len(os.environ["LEDGER_PROXY_PORT"]) != 0:
 	TCP_PROXY=(os.environ["LEDGER_PROXY_ADDRESS"], int(os.environ["LEDGER_PROXY_PORT"]))
-	
+# Change the format of the commands/responses.
+TCP_HEX=None
+if "TCP_HEX" in os.environ and len(os.environ["TCP_HEX"]) != 0:
+	TCP_HEX=os.environ["TCP_HEX"].split(':')
+	TCP_PROXY = (TCP_HEX[0], int(TCP_HEX[1], 0))
 # Force use of MCUPROXY if required
 PCSC=None
 if "PCSC" in os.environ and len(os.environ["PCSC"]) != 0:
@@ -203,7 +207,7 @@ def getDongle(debug=False, selectCommand=None):
 	elif MCUPROXY is not None:
 		return getDongleHTTP(remote_host=MCUPROXY, debug=debug)
 	elif TCP_PROXY is not None:
-		return getDongleTCP(server=TCP_PROXY[0], port=TCP_PROXY[1], debug=debug)
+		return getDongleTCP(server=TCP_PROXY[0], port=TCP_PROXY[1], debug=debug, hex_mode=(TCP_HEX is not None))
 	dev = None
 	hidDevicePath = None
 	ledger = True


### PR DESCRIPTION
The TCP_HEX env variable shall be present for this mode to be active.
The TCP proxy can thus be used with hex exchanges by setting TCP_HEX to:
<value of the LEDGER_PROXY_ADDRESS env variable>:<value of the LEDGER_PROXY_PORT env variable>