### PR TITLE
Test for AttributeError when reading secp256k1.HAS_ECDH

### DIFF
--- a/ledgerblue/ecWrapper.py
+++ b/ledgerblue/ecWrapper.py
@@ -21,7 +21,7 @@ import hashlib
 try:
 	import secp256k1
 	USE_SECP = secp256k1.HAS_ECDH
-except ImportError:
+except (ImportError, AttributeError):
 	USE_SECP = False
 
 if not USE_SECP:


### PR DESCRIPTION
On my system, the `secp256k1` was installed, but it did not have the field `HAS_ECDH`, causing this error when trying to replace the mcu firmware:

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/singala/.local/lib/python3.8/site-packages/ledgerblue/loadMCU.py", line 38, in <module>
    from .hexLoader import HexLoader
  File "/home/singala/.local/lib/python3.8/site-packages/ledgerblue/hexLoader.py", line 25, in <module>
    from .ecWrapper import PrivateKey, PublicKey
  File "/home/singala/.local/lib/python3.8/site-packages/ledgerblue/ecWrapper.py", line 23, in <module>
    USE_SECP = secp256k1.HAS_ECDH
AttributeError: module 'secp256k1' has no attribute 'HAS_ECDH'
```

This change fixed it.