### PR TITLE
fixed Assertion `ctx->pollfds_cnt >= internal_nfds' failed error for loadApp.py

### DIFF
--- a/ledgerblue/loadApp.py
+++ b/ledgerblue/loadApp.py
@@ -195,9 +195,10 @@ if __name__ == '__main__':
 
 	dongle = None
 	secret = None
+	dongle_open = False
 	if not args.offline:
 		dongle = getDongle(args.apdu)
-
+		dongle_open = True
 		if args.deployLegacy:
 			secret = getDeployedSecretV1(dongle, bytearray.fromhex(args.rootPrivateKey), args.targetId)
 		else:
@@ -311,3 +312,5 @@ if __name__ == '__main__':
 		loader.commit(signature)
 	else:
 		loader.run(args.bootAddr-printer.minAddr(), signature)
+	if(dongle_open == True):
+		dongle.close()


### PR DESCRIPTION
When Nano S is connected via USB-C to the host, a polling assertion fails.
This happens due to the device connection not being closed before the program exits.
One may get the following  error:

fixed Assertion `ctx->pollfds_cnt >= internal_nfds' failed.

Or simply:
Segmentation Fault, Core dumped

I have fixed it by properly closing the device. 
The same error occurs on many scripts.
Error reproduced on:
loadApp.py
loadMCU.py
runScript.py

Error fixed on:
loadApp.py
runScript.py