### PR TITLE
fixed Assertion `ctx->pollfds_cnt >= internal_nfds' failed error for runScript.py

### DIFF
--- a/ledgerblue/runScript.py
+++ b/ledgerblue/runScript.py
@@ -95,3 +95,4 @@ if __name__ == '__main__':
 			result = dongle.exchange(bytearray(data))
 		if args.apdu:
 			print("<= Clear " + str(result))
+	dongle.close()		


### PR DESCRIPTION
When Nano S is connected via USB-C to the host, a polling assertion fails.
This happens due to the device connection not being closed before the program exits.
One may get the following  error:

fixed Assertion `ctx->pollfds_cnt >= internal_nfds' failed.

Or simply:
Segmentation Fault, Core dumped

I have fixed it by properly closing the device. 
The same error occurs on many scripts.
Error reproduced on:
loadApp.py
loadMCU.py
runScript.py

Error fixed on:
loadApp.py
runScript.py