### PR TITLE
setup.py: Fix pyscard version for setuptools v67 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages=find_packages(),
     install_requires=['hidapi>=0.7.99', 'protobuf>=2.6.1', 'pycryptodomex>=3.6.1', 'future', 'ecpy>=0.9.0', 'pillow>=3.4.0', 'python-u2flib-host>=3.0.2', 'websocket_client>=0.56.0', 'nfcpy>=1.0.4'],
     extras_require = {
-	'smartcard': [ 'python-pyscard>=1.6.12-4build1' ]
+	'smartcard': [ 'python-pyscard>=1.6.12' ]
     },
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
A breaking change was introduced in setuptools v67: https://setuptools.pypa.io/en/stable/history.html#v67-0-0 This leads to an issue due to the fact that
python-pyscard>=1.6.12-4build1 is not a valid version.