### PR TITLE
Fix runApp appName parameter encoding

### DIFF
--- a/ledgerblue/runApp.py
+++ b/ledgerblue/runApp.py
@@ -52,6 +52,6 @@ if __name__ == '__main__':
 
     loader = HexLoader(dongle, 0xe0)
 
-    loader.runApp(args.appName)
+    loader.runApp(args.appName.encode())
 
     dongle.close()

--- a/ledgerblue/runApp.py
+++ b/ledgerblue/runApp.py
@@ -19,36 +19,39 @@
 
 import argparse
 
+
 def get_argparser():
-	parser = argparse.ArgumentParser("Run an application on the device.")
-	parser.add_argument("--targetId", help="The device's target ID (default is Ledger Blue)", type=auto_int, default=0x31000002)
-	parser.add_argument("--apdu", help="Display APDU log", action='store_true')
-	parser.add_argument("--rootPrivateKey", help="""The Signer private key used to establish a Secure Channel (otherwise
+    parser = argparse.ArgumentParser("Run an application on the device.")
+    parser.add_argument("--targetId", help="The device's target ID (default is Ledger Blue)", type=auto_int, default=0x31000002)
+    parser.add_argument("--apdu", help="Display APDU log", action='store_true')
+    parser.add_argument("--rootPrivateKey", help="""The Signer private key used to establish a Secure Channel (otherwise
 a random one will be generated)""")
-	parser.add_argument("--appName", help="The name of the application to run", required=True)
-	return parser
+    parser.add_argument("--appName", help="The name of the application to run", required=True)
+    return parser
+
 
 def auto_int(x):
-	return int(x, 0)
+    return int(x, 0)
+
 
 if __name__ == '__main__':
-	from .ecWrapper import PrivateKey
-	from .comm import getDongle
-	from .hexLoader import HexLoader
-	import binascii
+    from .ecWrapper import PrivateKey
+    from .comm import getDongle
+    from .hexLoader import HexLoader
+    import binascii
 
-	args = get_argparser().parse_args()
+    args = get_argparser().parse_args()
 
-	if args.rootPrivateKey is None:
-		privateKey = PrivateKey()
-		publicKey = binascii.hexlify(privateKey.pubkey.serialize(compressed=False))
-		print("Generated random root public key : %s" % publicKey)
-		args.rootPrivateKey = privateKey.serialize()
+    if args.rootPrivateKey is None:
+        privateKey = PrivateKey()
+        publicKey = binascii.hexlify(privateKey.pubkey.serialize(compressed=False))
+        print("Generated random root public key : %s" % publicKey)
+        args.rootPrivateKey = privateKey.serialize()
 
-	dongle = getDongle(args.apdu)
+    dongle = getDongle(args.apdu)
 
-	loader = HexLoader(dongle, 0xe0)
+    loader = HexLoader(dongle, 0xe0)
 
-	loader.runApp(args.appName)
+    loader.runApp(args.appName)
 
-	dongle.close()
+    dongle.close()


### PR DESCRIPTION
Would throw a `TypeError: string argument without an encoding` because the argument from the command line is read as a string.

Also fixed the indentation with 4 spaces instead of tabs for flake8.