### PR TITLE
Permission changes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,6 @@ on:
       - master
       - develop
 
-permissions:
-  id-token: write
-  attestations: write
-
 jobs:
   build_install:
     name: Build and install the Ledgerblue Python package
@@ -42,6 +38,11 @@ jobs:
     name: Build the Python package, and deploy if needed
     runs-on: public-ledgerhq-shared-small
     needs: build_install
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
+
     steps:
     - name: Clone
       uses: actions/checkout@v3


### PR DESCRIPTION
- Specific permission now only applies on the job needing them, instead of the whole workflow
- `contents` write permission added, so that the job is able to deploy a release.