### PR TITLE
Fix issue when a LP have a .hex with several areas

### DIFF
--- a/ledgerblue/hexLoader.py
+++ b/ledgerblue/hexLoader.py
@@ -942,14 +942,14 @@ class HexLoader:
                 if reverse:
                     chunk = data[offset - chunkLen : offset]
                     if self.createpackParams:
-                        self.loadPackSegmentChunk(offset - chunkLen, bytes(chunk))
+                        self.loadPackSegmentChunk(startAddress + offset - chunkLen, bytes(chunk))
                     else:
                         self.loadSegmentChunk(offset - chunkLen, bytes(chunk))
                 else:
                     chunk = data[offset : offset + chunkLen]
                     sha256.update(chunk)
                     if self.createpackParams:
-                        self.loadPackSegmentChunk(offset, bytes(chunk))
+                        self.loadPackSegmentChunk(startAddress + offset, bytes(chunk))
                     else:
                         self.loadSegmentChunk(offset, bytes(chunk))
                 if reverse:


### PR DESCRIPTION
When the .hex file have several areas, the offset is reset to 0 without taking in account startAddress value.
(this occur for exemple when a language pack is > 64 Kb, but not only)
As Language pack APDUs are not secure ins, we can't use the **selectSegment(startAddress)** feature.
=> We need to take in account **startAddress** with **offset** to compute the real offset.