### PR TITLE
removing develop branch references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
   pull_request:
     branches:
       - master
-      - develop
 
 jobs:
   build_install:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches:
       - master
-      - develop
 
 jobs:
   generate:


### PR DESCRIPTION
removing develop branch and subsequent references. This is to comply with trunk based development used in all  other LedgerHQ tool repositories