### PR TITLE
Remove unused `future` dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "hidapi>=0.7.99",
     "protobuf>=5.28,<6",
     "pycryptodomex>=3.6.1",
-    "future",
     "ecpy>=0.9.0",
     "pillow>=3.4.0",
     "python-u2flib-host>=3.0.2",


### PR DESCRIPTION
GitHub doesn't let me reopen #153 against a new branch, so there's that.

___


From what I can tell, this is unused, but causes troubles with Python 3.13.

https://github.com/NixOS/nixpkgs/issues/438625

https://github.com/PythonCharmers/python-future/issues/640