### PR TITLE
fix: regression impacting Nano S applications installation when commit command was missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.58] - 2026-06-23
+
+### Fixed
+
+- A regression impacting Nano S applications installation when commit command was missed
+
 ## [0.1.57] - 2026-06-11
 
 ### Changed

--- a/ledgerblue/hashApp.py
+++ b/ledgerblue/hashApp.py
@@ -141,7 +141,11 @@ def compute_app_hash(
 
     m = hashlib.sha256()
     m.update(struct.pack(">I", target_id))
-    m.update(struct.pack(">B", api_level))
+    # maintain compatibility with SDKs not handling API level: when api_level is
+    # -1 (e.g. Nano S), HexLoader.createApp omits the api_level byte from the
+    # createApp parameters.
+    if api_level != -1:
+        m.update(struct.pack(">B", api_level))
     m.update(struct.pack(">I", code_length))
     m.update(struct.pack(">I", data_length))
     m.update(struct.pack(">I", install_params_length))


### PR DESCRIPTION
`ledgerblue 0.1.57` added a new `compute_app_hash()` call between loading the code and the final commit step. That function packs the API level as an unsigned byte (`struct.pack(">B", api_level)`). Nano S has no API level, so it passes -1 → struct.pack(">B", -1) raises (must be 0–255). The crash aborts .apdu generation after the load/CRC lines but before the commit line (e00000000109) → the app never finalizes → "does not install."

(Newer devices pass a real api level ≥ 0, so they're unaffected.)